### PR TITLE
Fortran-tags as quelpa package

### DIFF
--- a/fortran-tags.el
+++ b/fortran-tags.el
@@ -1,3 +1,9 @@
+;;; fortran-tags.el --- Emacs plugin for source code indexing of modern Fortran
+
+;; Author: Raul Laasner
+;; Keywords: languages, tags, fortran
+;; Homepage: https://github.com/raullaasner
+
 ;; Copyright (C) 2015-2017 Raul Laasner
 ;; This file is distributed under the terms of the GNU General Public
 ;; License, see 'LICENSE' in the root directory of the present
@@ -36,6 +42,8 @@
 ;;   cur-scope:
 ;;     The scope at the position of the cursor as determined by
 ;;     fortran-find-scope.
+
+;;; Code:
 
 (setq VERSION "1.4.0")
 
@@ -375,3 +383,5 @@ procedures)."
 (add-hook 'f90-mode-hook 'fortran-tags-mode)
 
 (provide 'fortran-tags)
+
+;;; fortran-tags.el ends here


### PR DESCRIPTION
Hi @raullaasner ! 

Thank you for what seems to be the best tagging fortran/emacs system on the market! 
Helps to carry on that burden of a Physics Ph.D student.

With this pull request I'm asking you to enter some package metadata for your plugin, 
according to [this spec.](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html) Even if you do not want to bother with packaging and shipping to (m)elpa, it will help installing your package with [quelpa-use-package](https://github.com/quelpa/quelpa-use-package) directly from github.

I entered a minimal header; without it quelpa (read: use-package) throws `Package lacks a file header` exception. You might fill the rest of meta and let it be. Below I describe an alternative installation method, without a need to manually pull anything.

-----

While emacs's [use-package](https://github.com/jwiegley/use-package/) allows to install elisp modules as packages in a sane descriptive way (hooray!), `quelpa` can build them directly from github repos (hooray! x3). Assuming it is switched in your `.init.el`:

```
(use-package quelpa)
(use-package quelpa-use-package)
```
the forran-tags package could be installed with this:
```
(use-package fortran-tags
  :ensure nil
  :quelpa (fortran-tags :repo "vdikan/fortran-tags" :fetcher github)
  :config
  (setenv "PATH"
          (concat quelpa-dir "/build/fortran-tags:"
                  (getenv "PATH"))))
```
